### PR TITLE
removing generate id function, what's the point of having it?

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var createDomain = require('domain').create
-
+var count = 1;
 var domainMiddleware = module.exports = function(req, res, next) {
   var domain = createDomain();
-  domain.id = domainMiddleware.id(req);
+  domain.id = new Date().getTime() + (count++);
   domain.add(req);
   domain.add(res);
   domain.run(function() {
@@ -13,9 +13,3 @@ var domainMiddleware = module.exports = function(req, res, next) {
   });
 };
 
-var count = 0;
-//you can replace this method to
-//supply your own id builder
-domainMiddleware.id = function(req) {
-  return new Date().getTime() + (count++);
-};


### PR DESCRIPTION
I think the middleware should keep it simple if you really want to change the domain id we should pass it as part of the arguments/options
